### PR TITLE
Release/0.1.1

### DIFF
--- a/terraform/generate-ssm.tf
+++ b/terraform/generate-ssm.tf
@@ -3,21 +3,21 @@
 resource "aws_ssm_parameter" "aws_ssm_parameter_ps_idl_aqua" {
   name  = "${var.prefix}-idl-aqua"
   type  = "String"
-  value = "6"
+  value = "13"
 }
 
 # MODIS Terra
 resource "aws_ssm_parameter" "aws_ssm_parameter_ps_idl_terra" {
   name  = "${var.prefix}-idl-terra"
   type  = "String"
-  value = "6"
+  value = "13"
 }
 
 # VIIRS
 resource "aws_ssm_parameter" "aws_ssm_parameter_ps_idl_viirs" {
   name  = "${var.prefix}-idl-viirs"
   type  = "String"
-  value = "6"
+  value = "13"
 }
 
 # Floating

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -5,9 +5,9 @@ variable "app_name" {
 }
 
 variable "app_version" {
-  type        = number
+  type        = string
   description = "The application version number"
-  default     = 0.1
+  default     = "0.1.1"
 }
 
 variable "aws_region" {


### PR DESCRIPTION
### Description

Release of Cloud-Generate version 0.1.1.

Scope:

- Update IDL license numbers.
- Update version number.

The top-level Generate repository contains shared Terraform infrastructure for all Generate components. Documentation can be found here: <https://wiki.jpl.nasa.gov/pages/viewpage.action?spaceKey=PD&title=Generate+-+Cloud+-+AWS+Components#GenerateCloudAWSComponents-Generate>

### Overview of work done

Delivery Memo: <https://wiki.jpl.nasa.gov/display/PD/Cloud-Generate+v+0.1.1+Delivery+Memo>
ORR: <https://docs.google.com/presentation/d/1khB7ix7kHYdRMRxna61NFmqBAe7cM1zcxLVhw9OjF4M/edit?usp=sharing>

### Overview of verification done

#### Tested in SIT

Test Run Report: <https://cae-testrail.jpl.nasa.gov/testrail/index.php?/runs/view/39705&group_by=cases:title&group_order=asc>

#### Tested in UAT

UAT Test Results: <https://wiki.jpl.nasa.gov/display/PD/Generate+-+Cloud+-+UAT+Test+v0.1.1+Results>
